### PR TITLE
Update install steps to reference golang 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ sudo add-apt-repository ppa:longsleep/golang-backports
 sudo apt-get update
 
 # Install required dependencies.
-sudo apt -y install make tar wget curl rpm qemu-utils golang-1.15-go genisoimage python-minimal bison gawk
+sudo apt -y install make tar wget curl rpm qemu-utils golang-1.17-go genisoimage python-minimal bison gawk
 
 # Recommended but not required: `pigz` for faster compression operations.
 sudo apt -y install pigz
 
-# Fix go 1.15 link
-sudo ln -vsf /usr/lib/go-1.15/bin/go /usr/bin/go
+# Fix go 1.17 link
+sudo ln -vsf /usr/lib/go-1.17/bin/go /usr/bin/go
 
 # Install Docker.
 curl -fsSL https://get.docker.com -o get-docker.sh


### PR DESCRIPTION
Golang 1.17 is now required at a minimum to build CBL-Mariner 1.0, and this version also builds CBL-Mariner 2.0.