### PR TITLE
Adding git to the require dependecies

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ sudo add-apt-repository ppa:longsleep/golang-backports
 sudo apt-get update
 
 # Install required dependencies.
-sudo apt -y install make tar wget curl rpm qemu-utils golang-1.17-go genisoimage python-minimal bison gawk
+sudo apt -y install git make tar wget curl rpm qemu-utils golang-1.17-go genisoimage python-minimal bison gawk
 
 # Recommended but not required: `pigz` for faster compression operations.
 sudo apt -y install pigz


### PR DESCRIPTION
It does not seem like git comes by default to Ubuntu. Adding this to the require dependencies. Fixes issue #18 