### PR TITLE
Fix instructions to package gnuchess

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,9 @@ Clone the Fedora gnuchess repo and copy the spec and patch files into your gnuch
 ```bash
 cd CBL-MarinerDemo/SPECS/gnuchess
 git clone https://src.fedoraproject.org/rpms/gnuchess.git /tmp/gnuchess
+pushd /tmp/gnuchess
+git checkout 03a6481
+popd
 cp /tmp/gnuchess/gnuchess.spec .
 ```
 


### PR DESCRIPTION
This fixes an issue where the package build for gnuchess would fail ('Unable to hydrate file: gnuchess-6.2.9.tar.gz') due to a mismatch between the version of gnuchess at the head of the Fedora git repo (6.2.9 at the time of writing) and the version expected by our readme (6.2.7).

Full error log: https://paste.microsoft.com/8b82a2dc-926f-48d2-b7c0-b8bfdb4baef5